### PR TITLE
Minor update

### DIFF
--- a/UPDATES
+++ b/UPDATES
@@ -2,6 +2,7 @@
 
 ## 3.0.1
 
+- Ability to reinstall tracking a different branch
 - Platform version/distribution detection
 - Installation documentation updates
 - **Branch Configuration for Updates**: Added `CHIEF_CFG_UPDATE_BRANCH` configuration option to track either "main" (stable) or "dev" (bleeding-edge) branch for Chief updates

--- a/UPDATES
+++ b/UPDATES
@@ -2,6 +2,7 @@
 
 ## 3.0.1
 
+- Platform version/distribution detection
 - Installation documentation updates
 - **Branch Configuration for Updates**: Added `CHIEF_CFG_UPDATE_BRANCH` configuration option to track either "main" (stable) or "dev" (bleeding-edge) branch for Chief updates
   - Set `CHIEF_CFG_UPDATE_BRANCH="main"` for stable releases (default)

--- a/UPDATES
+++ b/UPDATES
@@ -1,5 +1,14 @@
 # Chief Updates
 
+## 3.0.1
+
+- Installation documentation updates
+- **Branch Configuration for Updates**: Added `CHIEF_CFG_UPDATE_BRANCH` configuration option to track either "main" (stable) or "dev" (bleeding-edge) branch for Chief updates
+  - Set `CHIEF_CFG_UPDATE_BRANCH="main"` for stable releases (default)
+  - Set `CHIEF_CFG_UPDATE_BRANCH="dev"` for latest features (⚠️ WARNING: not production ready)
+  - `chief.update` now automatically switches to configured branch before updating
+  - Update checking (`__check_for_updates`) now monitors the configured branch instead of current branch
+
 ## 3.0
 
 ### Upgrading from v2.1.1 to v3.0

--- a/VERSION
+++ b/VERSION
@@ -3,7 +3,7 @@
 # This file contains all version and URL constants used across Chief
 # Source this file to get consistent values in all scripts
 
-export CHIEF_VERSION="v3.0"
+export CHIEF_VERSION="v3.0.1"
 export CHIEF_REPO="https://github.com/randyoyarzabal/chief"
 export CHIEF_WEBSITE="https://chief.reonetlabs.us"  
 export CHIEF_AUTHOR="Randy E. Oyarzabal"

--- a/docs/README.md
+++ b/docs/README.md
@@ -174,22 +174,31 @@ chief.config_update --dry-run         # Preview changes before applying
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/randyoyarzabal/chief/refs/heads/main/tools/install.sh)"
 ```
 
-### 🌿 Development Branch Tracking
+### 🌿 Branch Tracking
 
-Chief now supports tracking either the stable or development branch:
+Chief supports tracking any valid Git branch for updates:
 
 ```bash
 # Track stable releases (default)
 chief.config_set update_branch main
 
-# Track bleeding-edge development features (⚠️ use with caution)
+# Track bleeding-edge development features (⚠️ use with caution)  
 chief.config_set update_branch dev
+
+# Track custom branches (team-specific, staging, etc.)
+chief.config_set update_branch staging
+chief.config_set update_branch release-v2.1
+chief.config_set update_branch feature/new-ui
+
+# Note: Both syntaxes are supported
+# ✅ Option 1: chief.config_set update_branch staging
+# ✅ Option 2: chief.config_set update_branch=staging
 
 # Update to your configured branch
 chief.update
 ```
 
-⚠️ **Important**: The `dev` branch contains the most current features but should be used with caution as it is not considered stable or production ready.
+⚠️ **Important**: Non-main branches may contain unstable features and should be used with caution in production environments.
 
 **What `chief.config_update` does:**
 
@@ -577,8 +586,9 @@ chief.config
 
 # Set configuration variables directly (use option name without CHIEF_CFG_ prefix)
 chief.config_set banner false         # Sets CHIEF_CFG_BANNER=false (prompts for confirmation)
+chief.config_set banner=false         # Same as above using key=value syntax
 chief.config_set --yes prompt true    # Sets CHIEF_CFG_PROMPT=true (no prompt)  
-chief.config_set colored_ls true      # Sets CHIEF_CFG_COLORED_LS=true (prompts for confirmation)
+chief.config_set colored_ls=true      # Sets CHIEF_CFG_COLORED_LS=true (prompts for confirmation)
 
 # List all configuration variables and current values  
 chief.config_set --list
@@ -602,11 +612,12 @@ chief.config_set config_set_interactive false
 | `CHIEF_CFG_SHORT_PATH` | `false` | Show only current directory name in prompt |
 | `CHIEF_CFG_COLORED_LS` | `false` | Colorize ls command output |
 | `CHIEF_CFG_CONFIG_SET_INTERACTIVE` | `true` | Prompt for confirmation in `chief.config_set` |
+| `CHIEF_CFG_CONFIG_UPDATE_BACKUP` | `true` | Create backups during config updates (only when changes made) |
 | `CHIEF_CFG_PLUGINS_TYPE` | `"local"` | Use `"local"` or `"remote"` plugins |
 | `CHIEF_CFG_SSH_KEYS_PATH` | _unset_ | Auto-load SSH keys from path |
 | `CHIEF_CFG_ALIAS` | _unset_ | Create short alias (e.g., `"cf"`) |
 | `CHIEF_CFG_AUTOCHECK_UPDATES` | `false` | Check for updates on startup |
-| `CHIEF_CFG_UPDATE_BRANCH` | `"main"` | Branch to track for updates: "main" (stable) or "dev" (⚠️ bleeding-edge) |
+| `CHIEF_CFG_UPDATE_BRANCH` | `"main"` | Branch to track for updates: any valid Git branch (⚠️ non-main may be unstable) |
 
 ### Plugin Configuration
 | Configuration | Description |

--- a/docs/README.md
+++ b/docs/README.md
@@ -174,6 +174,23 @@ chief.config_update --dry-run         # Preview changes before applying
 bash -c "$(curl -fsSL https://raw.githubusercontent.com/randyoyarzabal/chief/refs/heads/main/tools/install.sh)"
 ```
 
+### 🌿 Development Branch Tracking
+
+Chief now supports tracking either the stable or development branch:
+
+```bash
+# Track stable releases (default)
+chief.config_set update_branch main
+
+# Track bleeding-edge development features (⚠️ use with caution)
+chief.config_set update_branch dev
+
+# Update to your configured branch
+chief.update
+```
+
+⚠️ **Important**: The `dev` branch contains the most current features but should be used with caution as it is not considered stable or production ready.
+
 **What `chief.config_update` does:**
 
 - ✅ **Adds new features** - Automatically adds new configuration options from latest template
@@ -589,6 +606,7 @@ chief.config_set config_set_interactive false
 | `CHIEF_CFG_SSH_KEYS_PATH` | _unset_ | Auto-load SSH keys from path |
 | `CHIEF_CFG_ALIAS` | _unset_ | Create short alias (e.g., `"cf"`) |
 | `CHIEF_CFG_AUTOCHECK_UPDATES` | `false` | Check for updates on startup |
+| `CHIEF_CFG_UPDATE_BRANCH` | `"main"` | Branch to track for updates: "main" (stable) or "dev" (⚠️ bleeding-edge) |
 
 ### Plugin Configuration
 | Configuration | Description |

--- a/libs/core/chief_library.sh
+++ b/libs/core/chief_library.sh
@@ -1249,7 +1249,6 @@ ${CHIEF_COLOR_BLUE}Supported Configuration Variables:${CHIEF_NO_COLOR}
   ALIAS                     Custom alias for chief commands
 
 ${CHIEF_COLOR_YELLOW}Examples:${CHIEF_NO_COLOR}
-<<<<<<< HEAD
   $FUNCNAME --list                      # List all configuration variables
   $FUNCNAME banner true                 # Enable startup banner (with prompt)
   $FUNCNAME banner=true                 # Same as above using key=value syntax
@@ -1266,21 +1265,6 @@ ${CHIEF_COLOR_YELLOW}Examples:${CHIEF_NO_COLOR}
 ${CHIEF_COLOR_MAGENTA}Notes:${CHIEF_NO_COLOR}
 - Configuration options are case insensitive
 - Supports BOTH syntaxes: config_name value OR config_name=value
-=======
-  $FUNCNAME --list                        # List all configuration variables
-  $FUNCNAME banner=true                   # Enable startup banner (key=value format)
-  $FUNCNAME banner true                   # Enable startup banner (separate args format)
-  $FUNCNAME --yes banner=false            # Disable startup banner (no prompt)
-  $FUNCNAME colored_ls=true --yes         # Enable colored ls (no prompt)
-  $FUNCNAME prompt -y true                # Enable custom prompt (no prompt)
-  $FUNCNAME ssh_keys_path \"\$HOME/.ssh\" # Set SSH keys path (separate args)
-  $FUNCNAME ssh_keys_path=\"\$HOME/.ssh\" # Set SSH keys path (key=value format)
-  $FUNCNAME config_set_interactive=false  # Disable prompts globally
-
-${CHIEF_COLOR_MAGENTA}Notes:${CHIEF_NO_COLOR}
-- Configuration options are case insensitive
-- Both key=value and separate argument formats are supported
->>>>>>> 3cd4aebae7e646788a1cc9af4bb19fbd9e1df855
 - String values with spaces should be quoted
 - Changes take effect immediately after reload
 - Some changes may require terminal restart

--- a/templates/chief_config_template.sh
+++ b/templates/chief_config_template.sh
@@ -22,6 +22,17 @@ CHIEF_CFG_HINTS=true
 # $> chief.update
 CHIEF_CFG_AUTOCHECK_UPDATES=false
 
+# UPDATE CONFIGURATION
+####################################
+
+# Branch to track for Chief updates. Valid options are "main" or "dev".
+# When set to "main", Chief will track the stable release branch.
+# When set to "dev", Chief will track the development branch with bleeding-edge features.
+# WARNING: The "dev" branch contains the most current features but should be used with
+# caution as it is not considered stable or production ready.
+# This setting affects both automatic update checks and manual updates via chief.update.
+CHIEF_CFG_UPDATE_BRANCH="main"
+
 # PLUG-INS CONFIGURATION
 ####################################
 

--- a/templates/chief_config_template.sh
+++ b/templates/chief_config_template.sh
@@ -25,11 +25,12 @@ CHIEF_CFG_AUTOCHECK_UPDATES=false
 # UPDATE CONFIGURATION
 ####################################
 
-# Branch to track for Chief updates. Valid options are "main" or "dev".
+# Branch to track for Chief updates. Can be any valid Git branch name.
+# Common options: "main" (stable release), "dev" (bleeding-edge), or custom branches.
 # When set to "main", Chief will track the stable release branch.
 # When set to "dev", Chief will track the development branch with bleeding-edge features.
-# WARNING: The "dev" branch contains the most current features but should be used with
-# caution as it is not considered stable or production ready.
+# Custom branches can be used for specific versions or team-specific branches.
+# WARNING: Non-main branches may contain unstable features and should be used with caution.
 # This setting affects both automatic update checks and manual updates via chief.update.
 CHIEF_CFG_UPDATE_BRANCH="main"
 
@@ -127,6 +128,11 @@ CHIEF_CFG_COLORED_LS=false
 # Set to false for non-interactive operation by default (useful for automation/scripts).
 # Individual commands can still use --yes to skip prompts regardless of this setting.
 CHIEF_CFG_CONFIG_SET_INTERACTIVE=true
+
+# If set to true, chief.config_update will create timestamped backups when making changes.
+# Set to false to skip backup creation (useful for automation where you handle backups externally).
+# Only creates backups when actual changes are made to configuration file.
+CHIEF_CFG_CONFIG_UPDATE_BACKUP=true
 
 # Load private SSH keys into memory. 
 # Private keys are required to end in ".key" (symlinks are allowed)

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -23,7 +23,7 @@ if [[ -f "$VERSION_FILE" ]]; then
   source "$VERSION_FILE"
 else
   # Fallback constants if VERSION file doesn't exist (e.g., standalone install script)
-  export CHIEF_VERSION="v3.0"
+  export CHIEF_VERSION="v3.0.1"
   export CHIEF_GIT_REPO="https://github.com/randyoyarzabal/chief.git"
   export CHIEF_INSTALL_GIT_BRANCH="main"
   export CHIEF_WEBSITE="https://chief.reonetlabs.us"
@@ -104,7 +104,6 @@ print_banner() {
   echo -e "${YELLOW}\\___/_/ /_/_/\\___/_/ ${CYAN}${CHIEF_WEBSITE}${NC}"
   echo ""
   echo -e "${GREEN}SUCCESS: Chief installed successfully!${NC}"
-  echo -e "${BLUE}INFO: Restart your terminal or run: ${YELLOW}source ~/.bash_profile${NC}"
 }
 
 install_chief() {
@@ -276,9 +275,6 @@ setup_prompt
 echo -e "${BLUE}Step 4: Installation complete!${NC}"
 print_banner
 
-echo ""
-echo -e "${YELLOW}IMPORTANT: Restart your terminal for changes to take effect${NC}"
-echo -e "${CYAN}   Alternative: Run 'source ~/.bash_profile' in your current terminal${NC}"
 echo ""
 echo -e "${CYAN}NEXT STEPS:${NC}"
 echo -e "${CYAN}  1. Restart your terminal (or run: source ~/.bash_profile)${NC}"


### PR DESCRIPTION
- Ability to reinstall tracking a different branch
- Platform version/distribution detection
- Installation documentation updates
- **Branch Configuration for Updates**: Added `CHIEF_CFG_UPDATE_BRANCH` configuration option to track either "main" (stable) or "dev" (bleeding-edge) branch for Chief updates
  - Set `CHIEF_CFG_UPDATE_BRANCH="main"` for stable releases (default)
  - Set `CHIEF_CFG_UPDATE_BRANCH="dev"` for latest features (⚠️ WARNING: not production ready)
  - `chief.update` now automatically switches to configured branch before updating
  - Update checking (`__check_for_updates`) now monitors the configured branch instead of current branch